### PR TITLE
Remove `byte_decoder` in text_generation_utils

### DIFF
--- a/nemo/collections/nlp/modules/common/text_generation_utils.py
+++ b/nemo/collections/nlp/modules/common/text_generation_utils.py
@@ -595,10 +595,6 @@ def generate(
                     word = tokenizer.ids_to_tokens(token)
                     if isinstance(word, Iterable):
                         word = word[0]
-                    if hasattr(tokenizer.tokenizer, 'byte_decoder'):
-                        word = bytearray([tokenizer.tokenizer.byte_decoder[c] for c in word]).decode(
-                            'utf-8', errors='replace'
-                        )
                     words.append(word)
                 resp_sentences_seg.append(words)
             else:


### PR DESCRIPTION
# What does this PR do ?

Remove the byte decoding logic in text_generation_utils.py. This logic makes some tokenizers (i.e., TikTokenizer) crash because they don't have an attribute called `.tokenizer`, which is also not a required attributed in TokenizerSpec.

In addition, I searched the NeMo codebase and cannot find `byte_decoder` anywhere else, so I don't know where this method defined and how it should be used in the current codebase. Please let me know if there's any concern about removing this logic.

# Changelog 
- Remove `byte_decoder` in text_generation_utils when generating texts.

# Usage
N/A

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

@MaximumEntropy


# Additional Information
* Related to # (issue)
